### PR TITLE
withConfig 对数组进行合并

### DIFF
--- a/packages/utils/src/utils/index.ts
+++ b/packages/utils/src/utils/index.ts
@@ -19,7 +19,7 @@ export function toArray<T>(val: T | T[]): T[] {
 
 export const defu = createDefu((obj, key, value) => {
   if (Array.isArray(obj[key]) && Array.isArray(value)) {
-    obj[key] = value
+    obj[key] = [...obj[key], ...value]
     return true
   }
 })


### PR DESCRIPTION
当使用 withConfig 方法时，传入的数组类型会直接替换掉。为了提高灵活性，增加合并机制。